### PR TITLE
Rails 2 compatibilty

### DIFF
--- a/lib/i18n/one_sky/rails/railtie.rb
+++ b/lib/i18n/one_sky/rails/railtie.rb
@@ -1,8 +1,10 @@
 module I18n
   module Onesky
-    class Railtie < ::Rails::Railtie
-      rake_tasks do
-        load "i18n/one_sky/rails/tasks/i18n-one_sky.rake"
+    if Rails::VERSION::MAJOR >= 3
+      class Railtie < ::Rails::Railtie
+        rake_tasks do
+          load "i18n/one_sky/rails/tasks/i18n-one_sky.rake"
+        end
       end
     end
   end


### PR DESCRIPTION
This makes the gem compatible with Rails 2, since Railtie was only introduced in Rails 3.
