### PR TITLE
Fix issue with lost keys in YAML files

### DIFF
--- a/lib/i18n/one_sky/simple_client.rb
+++ b/lib/i18n/one_sky/simple_client.rb
@@ -52,7 +52,7 @@ module I18n
         phrases = {}
         Dir.glob("#{yaml_path}/**/*.yml").each do |path|
           hash = YAML::load(File.read(path))
-          phrases.merge!(hash[I18n.default_locale.to_s]) if hash.has_key?(I18n.default_locale.to_s)
+          phrases.deep_merge!(hash[I18n.default_locale.to_s]) if hash.has_key?(I18n.default_locale.to_s)
         end
         flatten_phrases(phrases)
       end


### PR DESCRIPTION
If you have two files
a.yml:

<pre>
  en:
     key:
       first: 'first'
</pre>

b.yml:

<pre>
  en:
    key:
       second: 'second'
</pre>


Depending of how the #all_phrases loads them, one of the keys will be lost, because Hash#merge only works on first level.
