### PR TITLE
Force UTF-8 encoding on YAML responses

### DIFF
--- a/lib/i18n/one_sky/simple_client.rb
+++ b/lib/i18n/one_sky/simple_client.rb
@@ -23,6 +23,7 @@ module I18n
           else
             yaml = platform.translation.download_yaml(locale_code)
             yaml_file_name = "#{locale_code}_one_sky.yml"
+            yaml.force_encoding('utf-8')
 
             if yaml.empty?
               puts "  locale: #{locale_code} - not downloading because it is empty (the old one would be deleted)"


### PR DESCRIPTION
When I fetch the YAML using JRuby 1.7.1 and 1.7.2
I get the response body in ASCII-8BIT and the file content
is broken. This differs from the CRuby behavior where I will
get the file in correct encoding.

This is an issue with RestClient. The behavior differs only for
HTTP responses that contain file attachments. In these cases
running on JRuby the RestClient will return ASCII-8BIT. I couldn't
isolate it to Net::HTTP, so I'm unsure where the actual problem is.

I'm forcing the UTF-8 as I think we _always_ expect UTF-8 as response
for the YAML files.

@OneSky I'm not exactly sure, but I think you always request an UTF-8 response as the request header send for the yaml files contains utf-8 content type, so I'm assuming that this is the expected encoding.

Sadly, using JRuby 1.7.1 doesn't respect that and set the encoding to ASCII-8BIT which leads to incorrect files.

If you find this patch correct, please merge and release.

Thanks.
